### PR TITLE
Adds prefix to parameter store paths

### DIFF
--- a/bin/configtool
+++ b/bin/configtool
@@ -20,6 +20,7 @@ function parseArgs() {
   const hab = subparsers.addParser("hab", { addHelp: true });
   hab.addArgument("mode", { choices: ["read", "write"] });
   hab.addArgument("service", { help: "The Hubs service name, e.g. janus-gateway." });
+  hab.addArgument(["--cmd"], { help: "The name of the Habitat binary (e.g. 'hab', 'bio'.)", defaultValue: "hab" });
   hab.addArgument(["--host"], { help: "The Habitat host to talk to.", defaultValue: "localhost" });
   hab.addArgument(["--httpPort"], { help: "The Habitat web API port.", defaultValue: 9631 });
   hab.addArgument(["--controlPort"], { help: "The Habitat suprvisor control port.", defaultValue: 9632 });
@@ -28,6 +29,7 @@ function parseArgs() {
   const ps = subparsers.addParser("ps", { addHelp: true });
   ps.addArgument("mode", { choices: ["read", "write", "delete"] });
   ps.addArgument("service", { help: "The Hubs service name, e.g. janus-gateway." });
+  ps.addArgument(["--prefix"], { help: "An optional prefix for Parameter Store values."});
   ps.addArgument(["--region"], { help: "The AWS region to talk to.", defaultValue: "us-west-1" });
   return parser.parseArgs();
 }
@@ -79,7 +81,7 @@ async function run(args) {
       throw new Error("Habitat binary not found. Please make sure the Habitat CLI is on your PATH.");
     }
 
-    const hab = new configtool.Habitat(args.host, args.httpPort, args.controlPort);
+    const hab = new configtool.Habitat(args.cmd, args.host, args.httpPort, args.controlPort);
     switch (args.mode) {
     case "read": {
       const output = await hab.read(args.service, args.group);
@@ -99,7 +101,7 @@ async function run(args) {
   }
 
   case "ps": {
-    const ps = new configtool.ParameterStore({ region: args.region });
+    const ps = new configtool.ParameterStore({ region: args.region }, args.prefix);
     switch (args.mode) {
     case "read": {
       const output = await ps.read(args.service);

--- a/bin/configtool
+++ b/bin/configtool
@@ -28,8 +28,7 @@ function parseArgs() {
 
   const ps = subparsers.addParser("ps", { addHelp: true });
   ps.addArgument("mode", { choices: ["read", "write", "delete"] });
-  ps.addArgument("service", { help: "The Hubs service name, e.g. janus-gateway." });
-  ps.addArgument(["--prefix"], { help: "An optional prefix for Parameter Store values."});
+  ps.addArgument("prefix", { help: "The prefix for Parameter Store values."});
   ps.addArgument(["--region"], { help: "The AWS region to talk to.", defaultValue: "us-west-1" });
   return parser.parseArgs();
 }
@@ -101,20 +100,20 @@ async function run(args) {
   }
 
   case "ps": {
-    const ps = new configtool.ParameterStore({ region: args.region }, args.prefix);
+    const ps = new configtool.ParameterStore({ region: args.region });
     switch (args.mode) {
     case "read": {
-      const output = await ps.read(args.service);
+      const output = await ps.read(args.prefix);
       console.log(serialize(output, args.format));
       return;
     }
     case "write": {
       const input = deserialize(await readToEnd(process.stdin), args.format);
-      await ps.write(args.service, input);
+      await ps.write(args.prefix, input);
       return;
     }
     case "delete": {
-      await ps.delete(args.service);
+      await ps.delete(args.prefix);
       return;
     }
     default: throw new Error(`Invalid mode '${args.mode}'.`);

--- a/src/habitat.js
+++ b/src/habitat.js
@@ -2,7 +2,6 @@ const http = require('http');
 const toml = require('@iarna/toml');
 const debug = require("debug")("configtool:hab");
 const childProcess = require('child_process');
-const habCommand = process.env.HAB_COMMAND || 'hab';
 
 // Runs the given command and arguments as a subprocess, passes the provided
 // string into stdin, and returns a promise that either resolves to stdout or
@@ -79,7 +78,8 @@ function sanitizeTree(obj) {
 }
 
 class Habitat {
-  constructor(httpHost = "localhost", httpPort = 9631, supHost = "localhost", supPort = 9632) {
+  constructor(habCommand = "hab", httpHost = "localhost", httpPort = 9631, supHost = "localhost", supPort = 9632) {
+    this.habCommand = habCommand;
     this.httpHost = httpHost;
     this.httpPort = httpPort;
     this.supHost = supHost;
@@ -91,7 +91,7 @@ class Habitat {
     const args = ["config", "apply", "-r", remote, `${service}.${group}`, version];
     const input = toml.stringify(config);
     debug(`Invoking hab: hab ${args.join(" ")}`);
-    return promisifyCommand(habCommand, args, input);
+    return promisifyCommand(this.habCommand, args, input);
   }
 
   async read(service, group) {

--- a/src/habitat.js
+++ b/src/habitat.js
@@ -2,6 +2,7 @@ const http = require('http');
 const toml = require('@iarna/toml');
 const debug = require("debug")("configtool:hab");
 const childProcess = require('child_process');
+const habCommand = process.env.HAB_COMMAND || 'hab';
 
 // Runs the given command and arguments as a subprocess, passes the provided
 // string into stdin, and returns a promise that either resolves to stdout or
@@ -90,7 +91,7 @@ class Habitat {
     const args = ["config", "apply", "-r", remote, `${service}.${group}`, version];
     const input = toml.stringify(config);
     debug(`Invoking hab: hab ${args.join(" ")}`);
-    return promisifyCommand('hab', args, input);
+    return promisifyCommand(habCommand, args, input);
   }
 
   async read(service, group) {

--- a/src/parameter-store.js
+++ b/src/parameter-store.js
@@ -44,7 +44,7 @@ class ParameterStore {
     // experimentally, the free tier requests per second PS can handle seems south of 4
     const ssm = new AWS.SSM(ssmOptions);
     this.throttle = new PromiseThrottle({ requestsPerSecond });
-    this.pathPrefix = pathPrefix ? `${pathPrefix}/` : "";
+    this.pathPrefix = pathPrefix;
     this.wrappers = promisifyService(ssm, ['deleteParameters', 'getParametersByPath', 'putParameter']);
   }
 

--- a/src/parameter-store.js
+++ b/src/parameter-store.js
@@ -86,7 +86,7 @@ class ParameterStore {
   }
 
   async delete(service) {
-    const params = await this._getAllParameters({ Path: `/${this.pathPrefix}${service}`, Recursive: true });
+    const params = await this._getAllParameters({ Path: `${this.pathPrefix}/${service}`, Recursive: true });
     const names = params.map(p => p.Name);
     const results = [];
     for (let i = 0; i < names.length; i += 10) { // API only lets you delete ten at once
@@ -100,12 +100,12 @@ class ParameterStore {
   }
 
   async write(service, config) {
-    return this._putSubtree(`/${this.pathPrefix}${service}`, config);
+    return this._putSubtree(`${this.pathPrefix}/${service}`, config);
   }
 
   async read(service) {
     let pairs = [];
-    const params = await this._getAllParameters({ Path: `/${this.pathPrefix}${service}`, Recursive: true, WithDecryption: true });
+    const params = await this._getAllParameters({ Path: `${this.pathPrefix}/${service}`, Recursive: true, WithDecryption: true });
     for (const p of params) {
       try {
         const val = JSON.parse(p.Value);

--- a/src/parameter-store.js
+++ b/src/parameter-store.js
@@ -44,7 +44,7 @@ class ParameterStore {
     // experimentally, the free tier requests per second PS can handle seems south of 4
     const ssm = new AWS.SSM(ssmOptions);
     this.throttle = new PromiseThrottle({ requestsPerSecond });
-    this.pathPrefix = pathPrefix;
+    this.pathPrefix = pathPrefix || "";
     this.wrappers = promisifyService(ssm, ['deleteParameters', 'getParametersByPath', 'putParameter']);
   }
 


### PR DESCRIPTION
Adds the ability to prefix the parameter store, and also parameterizes the habitat command (which can be `hab` or `bio`)