### PR TITLE
[Mozilla Branding Removal] Remove Mozilla branding from package metadata

### DIFF
--- a/bin/configtool
+++ b/bin/configtool
@@ -25,7 +25,7 @@ function parseArgs() {
   hab.addArgument(["--httpPort"], { help: "The Habitat web API port.", defaultValue: 9631 });
   hab.addArgument(["--controlPort"], { help: "The Habitat suprvisor control port.", defaultValue: 9632 });
   hab.addArgument(["--group"], { help: "The Habitat service group, e.g. prod.", defaultValue: "default" });
-  hab.addArgument(["--org"], { help: "The Habitat ring org, e.g. mozillareality.", defaultValue: null });
+  hab.addArgument(["--org"], { help: "The Habitat ring org, e.g. hubsfoundation.", defaultValue: null });
 
   const ps = subparsers.addParser("ps", { addHelp: true });
   ps.addArgument("mode", { choices: ["read", "write", "delete"] });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "A tool for reading and writing Hubs configs from the various stores.",
-  "repository": "github:MozillaReality/hubs-configtool",
+  "repository": "github:Hubs-Foundation/hubs-configtool",
   "main": "src/index.js",
   "scripts": {
     "lint": "eslint src",


### PR DESCRIPTION
## What?

Removes remaining Mozilla-branded references from `hubs-configtool` package metadata and CLI help text.

Specifically:

* Updates the CLI help example from `mozillareality` to `hubsfoundation`.
* Updates the package repository metadata from `MozillaReality/hubs-configtool` to `Hubs-Foundation/hubs-configtool`.

## Why?

This supports the ongoing Mozilla Branding Removal sprint by updating remaining project references that still point to Mozilla Reality.

## Examples

N/A

## How to test

1. Run:

```bash
grep -RniE "mozilla|moz://|mozillareality|hubs.mozilla|spoke by mozilla" . --exclude=LICENSE.md --exclude-dir=.git
```

2. Confirm there are no remaining matches outside of `LICENSE.md`.

## Documentation of functionality

No documentation changes are needed. This PR only updates package metadata and CLI help text.

## Limitations

This PR intentionally leaves `LICENSE.md` unchanged because it contains the Mozilla Public License text.

## Alternative implementations considered

None

## Open questions

None

## Additional details or related context

Part of the Mozilla Branding Removal sprint.
